### PR TITLE
Restore freetype and jpeg to gd

### DIFF
--- a/jakzal-phpqa-gd/Dockerfile
+++ b/jakzal-phpqa-gd/Dockerfile
@@ -1,6 +1,6 @@
 FROM jakzal/phpqa:php7.4-alpine
 
-RUN apk add --no-cache libpng-dev \
+RUN apk add --no-cache freetype-dev libjpeg-turbo-dev libpng-dev \
  && docker-php-ext-install -j$(nproc) iconv \
- && docker-php-ext-configure gd \
+ && docker-php-ext-configure gd --with-freetype --with-jpeg \
  && docker-php-ext-install -j$(nproc) gd

--- a/php-7.4-alpine-composer-gd/Dockerfile
+++ b/php-7.4-alpine-composer-gd/Dockerfile
@@ -7,8 +7,8 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 # git and unzip are necessary for Composer, mysql-client will install “mysqldump” command
 RUN apk add --no-cache git unzip mysql-client \
- && apk add --no-cache libpng-dev \
+ && apk add --no-cache freetype-dev libjpeg-turbo-dev libpng-dev \
  && docker-php-ext-install -j$(nproc) iconv \
- && docker-php-ext-configure gd \
+ && docker-php-ext-configure gd --with-freetype --with-jpeg \
  && docker-php-ext-install -j$(nproc) gd \
  && docker-php-ext-install pdo_mysql


### PR DESCRIPTION
Fix this error on CI:

> Error: Call to undefined function imagettftext()

See https://github.com/docker-library/php/issues/912#issuecomment-559918036